### PR TITLE
Check that a chart exists before calling destroy.

### DIFF
--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -79,6 +79,8 @@ export default Ember.Component.extend({
 
   _destroyChart: on('willDestroyElement', function() {
     this._super();
-    get(this, 'chart').destroy();
+    if (get(this, 'chart')) {
+      get(this, 'chart').destroy();  
+    }
   })
 });


### PR DESCRIPTION
Need to check for a chart before calling destroy.  Otherwise we can get the following error:
Uncaught TypeError: Cannot read property 'destroy' of null
